### PR TITLE
AI가 채용공고를 분석한 후 돌려주는 반환 값에 null이 포함되도록 개선 refactor 코드 구조 개선

### DIFF
--- a/src/main/java/com/careerfit/application/controller/ApplicationController.java
+++ b/src/main/java/com/careerfit/application/controller/ApplicationController.java
@@ -32,7 +32,7 @@ public class ApplicationController {
             @RequestBody ApplicationRegisterRequest request,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        Long memberId = userDetails.getUserId();
+        Long memberId = userDetails.getMember().getId();
         applicationService.registerApplication(request, memberId);
         return ApiResponse.success();
     }

--- a/src/main/java/com/careerfit/application/domain/Application.java
+++ b/src/main/java/com/careerfit/application/domain/Application.java
@@ -38,7 +38,6 @@ public class Application {
     @Column(nullable = false)
     private String applyPosition;
 
-    @Column(nullable = false)
     private LocalDateTime deadLine;
 
     private String location;

--- a/src/main/java/com/careerfit/application/dto/ApplicationRegisterRequest.java
+++ b/src/main/java/com/careerfit/application/dto/ApplicationRegisterRequest.java
@@ -1,6 +1,5 @@
 package com.careerfit.application.dto;
 
-import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import java.time.LocalDateTime;
@@ -13,7 +12,6 @@ public record ApplicationRegisterRequest(
         @NotBlank(message = "지원 직무는 비어 있을 수 없습니다.")
         String applyPosition,
 
-        @Future(message = "마감일은 현재보다 미래 시점이어야 합니다.")
         LocalDateTime deadline,
 
         String location,


### PR DESCRIPTION
## 📄Summary
현준님 AI 서버에서 돌려주는 반환 값에 변경점이 생겨서 그걸 반영한 픽스 PR입니다!

```
{
    "code": "200",
    "message": "채용 공고 분석에 성공했습니다.",
    "data": {
        "companyName": "카카오뱅크(kakaobank)",
        "applyPosition": "서버·백엔드",
        "deadline": null, // 이 경우 문제입니다.
        "location": "경기",
        "employmentType": "정규직",
        "careerRequirement": 5
    }
}
```
이런 식으로 deadline 부분에 nullable한 값이 올 수 있도록 변경했습니다!

<br><br>

## 🙋🏻 More
- 논의하고 싶은 내용 등

<br><br>

## 🔗관련 이슈
- Close #23 