### PR TITLE
이력서/포트폴리오 파일 메타 데이터 조회/생성/삭제 메서드 테스트 코드 작성

### DIFF
--- a/src/main/java/com/careerfit/attachmentfile/dto/FileInfoResponse.java
+++ b/src/main/java/com/careerfit/attachmentfile/dto/FileInfoResponse.java
@@ -4,10 +4,10 @@ import com.careerfit.attachmentfile.domain.AttachmentFile;
 import com.careerfit.document.domain.DocumentType;
 
 public record FileInfoResponse(
-    DocumentType documentType,
+    DocumentType attachmentFileType,
     Long id,
     String originalFileName,
-    String storedFileName,
+    String storedFilePath,
     String documentTitle,
     Long applicationId,
     String presignedUrl
@@ -16,7 +16,7 @@ public record FileInfoResponse(
     // 메타데이터 조회용
     public static FileInfoResponse fromAttachmentFile(AttachmentFile attachmentFile) {
         return new FileInfoResponse(
-            attachmentFile.getDocumentType(),
+            attachmentFile.getAttachmentFileType(),
             attachmentFile.getId(),
             attachmentFile.getOriginalFileName(),
             attachmentFile.getStoredFilePath(),
@@ -29,7 +29,7 @@ public record FileInfoResponse(
     // presignedUrl 발급용
     public static FileInfoResponse withPresignedUrl(AttachmentFile attachmentFile, String presignedUrl){
         return new FileInfoResponse(
-            attachmentFile.getDocumentType(),
+            attachmentFile.getAttachmentFileType(),
             attachmentFile.getId(),
             attachmentFile.getOriginalFileName(),
             attachmentFile.getStoredFilePath(),

--- a/src/main/java/com/careerfit/comment/controller/CommentApiController.java
+++ b/src/main/java/com/careerfit/comment/controller/CommentApiController.java
@@ -33,7 +33,7 @@ public class CommentApiController {
     @PostMapping
     public ResponseEntity<ApiResponse<Void>> createComment(
         @PathVariable Long documentId,
-        // 로그인 적용 시 @AuthenticationPrincipal로 변경 예정
+        // TODO: 로그인 적용 시 @AuthenticationPrincipal로 변경 예정
         @RequestParam Long memberId,
         @RequestBody CommentCreateRequest request
     ) {
@@ -48,7 +48,7 @@ public class CommentApiController {
     public ResponseEntity<ApiResponse<CommentInfoResponse>> getComment(
         @PathVariable Long documentId,
         @PathVariable Long commentId,
-        // 로그인 적용 시 @AuthenticationPrincipal로 변경 예정
+        // TODO: 로그인 적용 시 @AuthenticationPrincipal로 변경 예정
         @RequestParam Long memberId
     ){
         CommentInfoResponse response = commentQueryService.findComment(commentId, memberId);
@@ -59,7 +59,7 @@ public class CommentApiController {
     @GetMapping("/list")
     public ResponseEntity<ApiResponse<List<CommentInfoResponse>>> getCommentList(
         @PathVariable Long documentId,
-        // 로그인 적용 시 @AuthenticationPrincipal로 변경 예정
+        // TODO: 로그인 적용 시 @AuthenticationPrincipal로 변경 예정
         @RequestParam Long memberId
     ){
         List<CommentInfoResponse> response = commentQueryService.findAllComment(documentId, memberId);
@@ -71,7 +71,7 @@ public class CommentApiController {
     public ResponseEntity<ApiResponse<CommentInfoResponse>> updateComment(
         @PathVariable Long documentId,
         @PathVariable Long commentId,
-        // 로그인 적용 시 @AuthenticationPrincipal로 변경 예정
+        // TODO: 로그인 적용 시 @AuthenticationPrincipal로 변경 예정
         @RequestParam Long memberId,
         @Valid @RequestBody CommentUpdateRequest request
     ) {
@@ -84,7 +84,7 @@ public class CommentApiController {
     public ResponseEntity<Void> deleteComment(
         @PathVariable Long documentId,
         @PathVariable Long commentId,
-        // 로그인 적용 시 @AuthenticationPrincipal로 변경 예정
+        // TODO: 로그인 적용 시 @AuthenticationPrincipal로 변경 예정
         @RequestParam Long memberId
     ) {
         commentCommandService.deleteComment(commentId, memberId);

--- a/src/main/java/com/careerfit/comment/service/CommentCommandService.java
+++ b/src/main/java/com/careerfit/comment/service/CommentCommandService.java
@@ -22,7 +22,6 @@ public class CommentCommandService {
     private final MemberFinder memberFinder;
     private final CommentFinder commentFinder;
 
-    // comment 생성
     @Transactional
     public void createComment(
         Long documentId,
@@ -36,7 +35,6 @@ public class CommentCommandService {
         commentRepository.save(comment);
     }
 
-    // comment 수정
     @Transactional
     public CommentInfoResponse updateComment(
         Long commentId,
@@ -48,7 +46,6 @@ public class CommentCommandService {
         return CommentInfoResponse.from(comment);
     }
 
-    // comment 삭제
     @Transactional
     public void deleteComment(Long commentId, Long memberId) {
         // 멘토나, 해당 문서를 소유한 멘티만 해당 코멘트 리스트를 조회할 수 있도록 검증 로직 추가 필요: 이후 추가 예정

--- a/src/main/java/com/careerfit/comment/service/CommentQueryService.java
+++ b/src/main/java/com/careerfit/comment/service/CommentQueryService.java
@@ -16,7 +16,6 @@ public class CommentQueryService {
     private final CommentRepository commentRepository;
     private final CommentFinder commentFinder;
 
-    // comment 단건 조회
     public CommentInfoResponse findComment(Long commentId, Long memberId) {
         Comment comment = commentFinder.findCommentOrThrow(commentId);
 
@@ -25,7 +24,6 @@ public class CommentQueryService {
         return CommentInfoResponse.from(comment);
     }
 
-    // comment 리스트 조회
     public List<CommentInfoResponse> findAllComment(Long documentId, Long memberId) {
         // 멘토나, 해당 문서를 소유한 멘티만 해당 코멘트 리스트를 조회할 수 있도록 검증 로직 추가 필요: 이후 추가 예정
 

--- a/src/test/java/com/careerfit/AttachmentFile/service/AttachmentFileCommandServiceTest.java
+++ b/src/test/java/com/careerfit/AttachmentFile/service/AttachmentFileCommandServiceTest.java
@@ -1,0 +1,170 @@
+package com.careerfit.AttachmentFile.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.careerfit.application.domain.Application;
+import com.careerfit.application.domain.ApplicationStatus;
+import com.careerfit.application.service.ApplicationFinder;
+import com.careerfit.attachmentfile.domain.AttachmentFile;
+import com.careerfit.attachmentfile.repository.AttachmentFileRepository;
+import com.careerfit.attachmentfile.service.AttachmentFileCommandService;
+import com.careerfit.attachmentfile.service.AttachmentFileFinder;
+import com.careerfit.auth.domain.OAuthProvider;
+import com.careerfit.document.domain.DocumentType;
+import com.careerfit.global.util.DocumentUtil;
+import com.careerfit.member.domain.Member;
+import com.careerfit.member.domain.MenteeProfile;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AttachmentFileCommandServiceTest {
+
+    @Mock
+    private AttachmentFileRepository attachmentFileRepository;
+
+    @Mock
+    private AttachmentFileFinder attachmentFileFinder;
+
+    @Mock
+    private ApplicationFinder applicationFinder;
+
+    @InjectMocks
+    private AttachmentFileCommandService attachmentFileCommandService;
+
+    private MenteeProfile menteeProfile1;
+    private MenteeProfile menteeProfile2;
+    private Member mentee1;
+    private Member mentee2;
+    private Application app1;
+    private Application app2;
+    private AttachmentFile file1;
+    private AttachmentFile file2;
+    private AttachmentFile file3;
+
+
+    @BeforeEach
+    void setUp() {
+        menteeProfile1 = MenteeProfile.of("경북대학교", "컴퓨터학부", 2026,
+            List.of("카카오", "라인", "네이버"), List.of("백엔드", "서버 개발"));
+        menteeProfile2 = MenteeProfile.of("영남대학교", "소프트웨어학과", 2027,
+            List.of("당근", "쿠팡", "토스"), List.of("IOS"));
+
+        mentee1 = Member.mentee("mentee1@gmail.com", "010-3333-3333", "김철수", null,
+            OAuthProvider.KAKAO, "oauth_id_3", menteeProfile1);
+        mentee2 = Member.mentee("mentee2@gmail.com", "010-4444-4444", "박영희", null,
+            OAuthProvider.KAKAO, "oauth_id_4", menteeProfile2);
+
+        app1 = createApplication(1L, "카카오", "2025 신입 백엔드 개발자", mentee1,
+            ApplicationStatus.PREPARING);
+        app2 = createApplication(2L, "라인", "2025 신입 iOS 개발자", mentee2,
+            ApplicationStatus.APPLIED);
+
+        file1 = AttachmentFile.builder()
+            .id(1L)
+            .originalFileName("MyResume")
+            .storedFilePath("applications/1/resumes/a42f8cd9-7391-437d-91ef-9b78e462db9c_MyResume1_MyResume")
+            .title("MyResume1")
+            .attachmentFileType(DocumentType.RESUME)
+            .build();
+        app1.addDocument(file1);
+
+        file2 = AttachmentFile.builder()
+            .id(2L)
+            .originalFileName("MyPortfolio")
+            .storedFilePath("applications/1/portfolios/a42f8cd9-7391-437d-91ef-9b78e462db9c_MyPortfolio1_MyPortfolio")
+            .title("MyPortfolio1")
+            .attachmentFileType(DocumentType.PORTFOLIO)
+            .build();
+        app2.addDocument(file2);
+
+        file3 = AttachmentFile.builder()
+            .id(3L)
+            .originalFileName("MyResumeV2")
+            .storedFilePath("applications/1/resumes/a42f8cd9-7391-437d-91ef-9b78e462db9c_MyResume2_MyResumeV2")
+            .title("MyResume2")
+            .attachmentFileType(DocumentType.RESUME)
+            .build();
+        app1.addDocument(file3);
+    }
+
+    @Test
+    @DisplayName("파일 메타 데이터 저장에 성공하면 200")
+    void saveFile() {
+
+        // uniqueFileName으로부터 applicationId, documentTitle, originalFileName 추출
+        // given
+        String uniqueFileName = "applications/1/resumes/a42f8cd9-7391-437d-91ef-9b78e462db9c_MyResume1_MyResume";
+
+        // when
+        Long extractedApplicationId = DocumentUtil.extractApplicationId(uniqueFileName);
+        String documentTitle = DocumentUtil.extractDocumentTitle(uniqueFileName);
+        String originalFileName = DocumentUtil.extractOriginalFileName(uniqueFileName);
+
+        // then
+        assertThat(extractedApplicationId).isEqualTo(1L);
+        assertThat(documentTitle).isEqualTo("MyResume1");
+        assertThat(originalFileName).isEqualTo("MyResume");
+
+
+        // 실제 파일 메타 데이터 저장
+        // given
+        Long requestApplicationId = 1L;
+        DocumentType documentType = DocumentType.RESUME;
+        when(applicationFinder.getApplicationOrThrow(extractedApplicationId)).thenReturn(app1);
+        ArgumentCaptor<AttachmentFile> attachmentFileCaptor = ArgumentCaptor.forClass(AttachmentFile.class);
+
+        // when
+        attachmentFileCommandService.saveFile(requestApplicationId, uniqueFileName, documentType);
+
+        // then
+        verify(attachmentFileRepository).save(attachmentFileCaptor.capture());
+        AttachmentFile savedFile = attachmentFileCaptor.getValue();
+        assertThat(savedFile.getApplication()).isEqualTo(app1);
+        assertThat(savedFile.getStoredFilePath()).isEqualTo(uniqueFileName);
+        assertThat(savedFile.getOriginalFileName()).isEqualTo(originalFileName);
+        assertThat(savedFile.getTitle()).isEqualTo(documentTitle);
+    }
+
+    @Test
+    @DisplayName("파일 메타 데이터 삭제에 성공하면 200")
+    void deleteFile() {
+        // given
+        Long applicationId = 1L;
+        Long attachmentFileId = 3L;
+        when(attachmentFileFinder.findAttachmentFileOrThrow(attachmentFileId)).thenReturn(file3);
+        doNothing().when(attachmentFileRepository).deleteById(attachmentFileId);
+
+        // when
+        attachmentFileCommandService.deleteFile(applicationId, attachmentFileId);
+
+        // then
+        verify(attachmentFileFinder, times(1)).findAttachmentFileOrThrow(attachmentFileId);
+        verify(attachmentFileRepository, times(1)).deleteById(attachmentFileId);
+    }
+
+
+    private Application createApplication(Long id, String company, String position, Member mentee,
+        ApplicationStatus status) {
+        return Application.builder()
+            .id(id)
+            .companyName(company)
+            .applyPosition(position)
+            .deadLine(LocalDateTime.now().plusDays(10))
+            .applicationStatus(status)
+            .member(mentee)
+            .build();
+    }
+}

--- a/src/test/java/com/careerfit/AttachmentFile/service/AttachmentFileQueryServiceTest.java
+++ b/src/test/java/com/careerfit/AttachmentFile/service/AttachmentFileQueryServiceTest.java
@@ -1,0 +1,157 @@
+package com.careerfit.AttachmentFile.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.careerfit.application.domain.Application;
+import com.careerfit.application.domain.ApplicationStatus;
+import com.careerfit.application.service.ApplicationFinder;
+import com.careerfit.attachmentfile.domain.AttachmentFile;
+import com.careerfit.attachmentfile.dto.FileInfoResponse;
+import com.careerfit.attachmentfile.repository.AttachmentFileRepository;
+import com.careerfit.attachmentfile.service.AttachmentFileFinder;
+import com.careerfit.attachmentfile.service.AttachmentFileQueryService;
+import com.careerfit.auth.domain.OAuthProvider;
+import com.careerfit.document.domain.DocumentType;
+import com.careerfit.member.domain.Member;
+import com.careerfit.member.domain.MenteeProfile;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AttachmentFileQueryServiceTest {
+
+    @Mock
+    private AttachmentFileRepository attachmentFileRepository;
+
+    @Mock
+    private AttachmentFileFinder attachmentFileFinder;
+
+    @InjectMocks
+    private AttachmentFileQueryService attachmentFileQueryService;
+
+    private MenteeProfile menteeProfile1;
+    private MenteeProfile menteeProfile2;
+    private Member mentee1;
+    private Member mentee2;
+    private Application app1;
+    private Application app2;
+    private AttachmentFile file1;
+    private AttachmentFile file2;
+    private AttachmentFile file3;
+
+
+    @BeforeEach
+    void setUp() {
+        menteeProfile1 = MenteeProfile.of("경북대학교", "컴퓨터학부", 2026,
+            List.of("카카오", "라인", "네이버"), List.of("백엔드", "서버 개발"));
+        menteeProfile2 = MenteeProfile.of("영남대학교", "소프트웨어학과", 2027,
+            List.of("당근", "쿠팡", "토스"), List.of("IOS"));
+
+        mentee1 = Member.mentee("mentee1@gmail.com", "010-3333-3333", "김철수", null,
+            OAuthProvider.KAKAO, "oauth_id_3", menteeProfile1);
+        mentee2 = Member.mentee("mentee2@gmail.com", "010-4444-4444", "박영희", null,
+            OAuthProvider.KAKAO, "oauth_id_4", menteeProfile2);
+
+        app1 = createApplication(1L, "카카오", "2025 신입 백엔드 개발자", mentee1,
+            ApplicationStatus.PREPARING);
+        app2 = createApplication(2L, "라인", "2025 신입 iOS 개발자", mentee2,
+            ApplicationStatus.APPLIED);
+
+        file1 = AttachmentFile.builder()
+            .id(1L)
+            .originalFileName("이력서.pdf")
+            .storedFilePath("resumes/uuid-resume.pdf")
+            .title("김철수 이력서")
+            .attachmentFileType(DocumentType.RESUME)
+            .build();
+        app1.addDocument(file1);
+
+        file2 = AttachmentFile.builder()
+            .id(2L)
+            .originalFileName("포트폴리오.pdf")
+            .storedFilePath("portfolios/uuid-portfolio.pdf")
+            .title("박영희 포트폴리오")
+            .attachmentFileType(DocumentType.PORTFOLIO)
+            .build();
+        app2.addDocument(file2);
+
+        file3 = AttachmentFile.builder()
+            .id(3L)
+            .originalFileName("이력서_수정본.pdf")
+            .storedFilePath("resumes/uuid-resume-v2.pdf")
+            .title("김철수 이력서 수정")
+            .attachmentFileType(DocumentType.RESUME)
+            .application(app1)
+            .build();
+        app1.addDocument(file3);
+    }
+
+    @Test
+    @DisplayName("첨부파일 메타 데이터 단건 조회에 성공하면 200")
+    void getFileInfo() {
+
+        // given
+        Long applicationId = 1L;
+        Long attachmentFileId = 1L;
+        when(attachmentFileFinder.findAttachmentFileOrThrow(applicationId)).thenReturn(file1);
+
+        // when
+        FileInfoResponse response = attachmentFileQueryService.getFileInfo(applicationId,
+            attachmentFileId);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.id()).isEqualTo(1L);
+        assertThat(response.applicationId()).isEqualTo(1L);
+        assertThat(response.originalFileName()).isEqualTo("이력서.pdf");
+        assertThat(response.attachmentFileType()).isEqualTo(DocumentType.RESUME);
+    }
+
+    @Test
+    @DisplayName("첨부파일 메타 데이터 리스트 조회에 성공하면 200")
+    void getFileInfoList() {
+        // given
+        Long applicationId = 1L;
+        DocumentType documentType = DocumentType.RESUME;
+        when(attachmentFileRepository.findAllByApplicationId(applicationId))
+            .thenReturn(app1.getDocuments().stream()
+                .filter(each -> each instanceof AttachmentFile)
+                .map(each -> (AttachmentFile) each)
+                .toList());
+
+        // when
+        List<FileInfoResponse> response = attachmentFileQueryService.getFileInfoList(applicationId,
+            documentType);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response).hasSize(2);
+        assertThat(response).extracting(FileInfoResponse::id)
+            .containsExactlyInAnyOrder(1L, 3L);
+        assertThat(response).extracting(FileInfoResponse::attachmentFileType)
+            .allMatch(type -> type.equals(documentType));
+        assertThat(response.get(0).originalFileName()).isEqualTo(file1.getOriginalFileName());
+        assertThat(response.get(1).originalFileName()).isEqualTo(file3.getOriginalFileName());
+    }
+
+
+    private Application createApplication(Long id, String company, String position, Member mentee,
+        ApplicationStatus status) {
+        return Application.builder()
+            .id(id)
+            .companyName(company)
+            .applyPosition(position)
+            .deadLine(LocalDateTime.now().plusDays(10))
+            .applicationStatus(status)
+            .member(mentee)
+            .build();
+    }
+}


### PR DESCRIPTION
## 📄Summary
- 첨부파일(이력서/포트폴리오)에 대한 파일 메타 데이터 조회/생성/삭제 메서드 테스트 코드를 작성했습니다.

<br><br>

## 작업 내용
- AttachmentFileCommandService의 파일 메타 데이터 생성/삭제 메서드에 대한 테스트 코드 작성
- AttachmentFileQueryService의 파일 메타 데이터 단건 조회/리스트 조회 메서드에 대한 테스트 코드 작성
- 필요 없는 주석 삭제 및 `// TODO` 주석 추가
- FileInfoResponse dto의 documentType 필드명을 의미상 적절하게 attachmentFileType으로 수정

## 🙋🏻 More
- #56 PR과 마찬가지로 아직 이전 PR들이 머지되지 않아서 이전 브랜치를 base branch로 설정했습니다.
- 이전 #55 , #56 PR이 머지되고 나면, 이 PR의 base branch를 develop으로 변경하고 머지해야 할 것 같습니다.

<br><br>

## 🔗관련 이슈
- #58 