### PR TITLE
AttachmentFile, Comments 조회 기능에 페이지네이션 적용

### DIFF
--- a/src/main/java/com/careerfit/attachmentfile/controller/AttachmentFileApiController.java
+++ b/src/main/java/com/careerfit/attachmentfile/controller/AttachmentFileApiController.java
@@ -11,8 +11,9 @@ import com.careerfit.attachmentfile.service.S3QueryService;
 import com.careerfit.document.domain.DocumentType;
 import com.careerfit.global.dto.ApiResponse;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -87,12 +88,13 @@ public class AttachmentFileApiController {
 
     // 파일 메타 데이터 리스트 조회
     @GetMapping("/metadata/list")
-    public ResponseEntity<ApiResponse<List<FileInfoResponse>>> getFileMetaDataList(
+    public ResponseEntity<ApiResponse<Page<FileInfoResponse>>> getFileMetaDataList(
         @PathVariable(name = "application-id") Long applicationId,
-        @RequestParam(name = "document-type") DocumentType documentType
+        @RequestParam(name = "document-type") DocumentType documentType,
+        Pageable pageable
     ) {
-        List<FileInfoResponse> response = attachmentFileQueryService.getFileInfoList(applicationId,
-            documentType);
+        Page<FileInfoResponse> response = attachmentFileQueryService.getFileInfoList(applicationId,
+            documentType, pageable);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/careerfit/attachmentfile/controller/AttachmentFileApiController.java
+++ b/src/main/java/com/careerfit/attachmentfile/controller/AttachmentFileApiController.java
@@ -1,5 +1,6 @@
 package com.careerfit.attachmentfile.controller;
 
+import com.careerfit.attachmentfile.domain.AttachmentFileType;
 import com.careerfit.attachmentfile.dto.FileInfoResponse;
 import com.careerfit.attachmentfile.dto.GetPresignedUrlResponse;
 import com.careerfit.attachmentfile.dto.FileUploadRequest;
@@ -8,7 +9,6 @@ import com.careerfit.attachmentfile.service.AttachmentFileCommandService;
 import com.careerfit.attachmentfile.service.AttachmentFileQueryService;
 import com.careerfit.attachmentfile.service.S3CommandService;
 import com.careerfit.attachmentfile.service.S3QueryService;
-import com.careerfit.document.domain.DocumentType;
 import com.careerfit.global.dto.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -41,12 +41,12 @@ public class AttachmentFileApiController {
     @PostMapping("/file-upload")
     public ResponseEntity<ApiResponse<PutPresignedUrlResponse>> generatePostPresignedUrl(
         @PathVariable(name = "application-id") Long applicationId,
-        @RequestParam(name = "document-type") DocumentType documentType,
+        @RequestParam(name = "document-type") AttachmentFileType attachmentFileType,
         @Valid @RequestBody FileUploadRequest request
     ) {
         PutPresignedUrlResponse response = s3CommandService.generatePutPresignedUrl(applicationId,
-            documentType, request);
-        attachmentFileCommandService.saveFile(applicationId, response.uniqueFileName(), documentType);
+            attachmentFileType, request);
+        attachmentFileCommandService.saveFile(applicationId, response.uniqueFileName(), attachmentFileType);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
@@ -90,11 +90,11 @@ public class AttachmentFileApiController {
     @GetMapping("/metadata/list")
     public ResponseEntity<ApiResponse<Page<FileInfoResponse>>> getFileMetaDataList(
         @PathVariable(name = "application-id") Long applicationId,
-        @RequestParam(name = "document-type") DocumentType documentType,
+        @RequestParam(name = "document-type") AttachmentFileType attachmentFileType,
         Pageable pageable
     ) {
         Page<FileInfoResponse> response = attachmentFileQueryService.getFileInfoList(applicationId,
-            documentType, pageable);
+            attachmentFileType, pageable);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/careerfit/attachmentfile/domain/AttachmentFile.java
+++ b/src/main/java/com/careerfit/attachmentfile/domain/AttachmentFile.java
@@ -32,28 +32,15 @@ public class AttachmentFile extends Document {
     @Column(nullable = false)
     private AttachmentFileType attachmentFileType;
 
-    public static AttachmentFile createResume(String originalFileName, String storedFilePath, String documentTitle,
-        Application application) {
+    public static AttachmentFile of(String originalFileName, String storedFilePath, String documentTitle,
+    Application application, AttachmentFileType attachmentFileType) {
 
         return AttachmentFile.builder()
             .originalFileName(originalFileName)
             .storedFilePath(storedFilePath)
             .title(documentTitle)
             .application(application)
-            .attachmentFileType(AttachmentFileType.RESUME)
+            .attachmentFileType(attachmentFileType)
             .build();
     }
-
-    public static AttachmentFile createPortfolio(String originalFileName, String storedFilePath, String documentTitle,
-        Application application) {
-
-        return AttachmentFile.builder()
-            .originalFileName(originalFileName)
-            .storedFilePath(storedFilePath)
-            .title(documentTitle)
-            .application(application)
-            .attachmentFileType(AttachmentFileType.PORTFOLIO)
-            .build();
-    }
-
 }

--- a/src/main/java/com/careerfit/attachmentfile/domain/AttachmentFile.java
+++ b/src/main/java/com/careerfit/attachmentfile/domain/AttachmentFile.java
@@ -2,7 +2,6 @@ package com.careerfit.attachmentfile.domain;
 
 import com.careerfit.application.domain.Application;
 import com.careerfit.document.domain.Document;
-import com.careerfit.document.domain.DocumentType;
 import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
@@ -31,7 +30,7 @@ public class AttachmentFile extends Document {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private DocumentType attachmentFileType;
+    private AttachmentFileType attachmentFileType;
 
     public static AttachmentFile createResume(String originalFileName, String storedFilePath, String documentTitle,
         Application application) {
@@ -41,7 +40,7 @@ public class AttachmentFile extends Document {
             .storedFilePath(storedFilePath)
             .title(documentTitle)
             .application(application)
-            .attachmentFileType(DocumentType.RESUME)
+            .attachmentFileType(AttachmentFileType.RESUME)
             .build();
     }
 
@@ -53,7 +52,7 @@ public class AttachmentFile extends Document {
             .storedFilePath(storedFilePath)
             .title(documentTitle)
             .application(application)
-            .attachmentFileType(DocumentType.PORTFOLIO)
+            .attachmentFileType(AttachmentFileType.PORTFOLIO)
             .build();
     }
 

--- a/src/main/java/com/careerfit/attachmentfile/domain/AttachmentFileType.java
+++ b/src/main/java/com/careerfit/attachmentfile/domain/AttachmentFileType.java
@@ -1,0 +1,5 @@
+package com.careerfit.attachmentfile.domain;
+
+public enum AttachmentFileType {
+    RESUME, PORTFOLIO
+}

--- a/src/main/java/com/careerfit/attachmentfile/dto/FileInfoResponse.java
+++ b/src/main/java/com/careerfit/attachmentfile/dto/FileInfoResponse.java
@@ -1,10 +1,10 @@
 package com.careerfit.attachmentfile.dto;
 
 import com.careerfit.attachmentfile.domain.AttachmentFile;
-import com.careerfit.document.domain.DocumentType;
+import com.careerfit.attachmentfile.domain.AttachmentFileType;
 
 public record FileInfoResponse(
-    DocumentType attachmentFileType,
+    AttachmentFileType attachmentFileType,
     Long id,
     String originalFileName,
     String storedFilePath,

--- a/src/main/java/com/careerfit/attachmentfile/repository/AttachmentFileRepository.java
+++ b/src/main/java/com/careerfit/attachmentfile/repository/AttachmentFileRepository.java
@@ -1,9 +1,12 @@
 package com.careerfit.attachmentfile.repository;
 
 import com.careerfit.attachmentfile.domain.AttachmentFile;
-import java.util.List;
+import com.careerfit.document.domain.DocumentType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AttachmentFileRepository extends JpaRepository<AttachmentFile, Long> {
-    List<AttachmentFile> findAllByApplicationId(Long applicationId);
+    Page<AttachmentFile> findAllByApplicationIdAndAttachmentFileType(Long applicationId,
+        DocumentType attachmentFileType, Pageable pageable);
 }

--- a/src/main/java/com/careerfit/attachmentfile/repository/AttachmentFileRepository.java
+++ b/src/main/java/com/careerfit/attachmentfile/repository/AttachmentFileRepository.java
@@ -1,12 +1,12 @@
 package com.careerfit.attachmentfile.repository;
 
 import com.careerfit.attachmentfile.domain.AttachmentFile;
-import com.careerfit.document.domain.DocumentType;
+import com.careerfit.attachmentfile.domain.AttachmentFileType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AttachmentFileRepository extends JpaRepository<AttachmentFile, Long> {
     Page<AttachmentFile> findAllByApplicationIdAndAttachmentFileType(Long applicationId,
-        DocumentType attachmentFileType, Pageable pageable);
+        AttachmentFileType attachmentFileType, Pageable pageable);
 }

--- a/src/main/java/com/careerfit/attachmentfile/service/AttachmentFileCommandService.java
+++ b/src/main/java/com/careerfit/attachmentfile/service/AttachmentFileCommandService.java
@@ -36,18 +36,8 @@ public class AttachmentFileCommandService {
         }
 
         Application application = applicationFinder.getApplicationOrThrow(applicationId);
-        AttachmentFile attachmentFile;
-
-        if (attachmentFileType.equals(AttachmentFileType.RESUME)) {
-            attachmentFile = AttachmentFile.createResume(originalFileName, uniqueFileName,
-                documentTitle, application);
-        } else if (attachmentFileType.equals(AttachmentFileType.PORTFOLIO)) {
-            attachmentFile = AttachmentFile.createPortfolio(originalFileName, uniqueFileName,
-                documentTitle, application);
-        } else {
-            throw new ApplicationException(DocumentErrorCode.DOCUMENT_INVALID_TYPE);
-        }
-
+        AttachmentFile attachmentFile = AttachmentFile.of(originalFileName, uniqueFileName,
+            documentTitle, application, attachmentFileType);
         attachmentFileRepository.save(attachmentFile);
     }
 

--- a/src/main/java/com/careerfit/attachmentfile/service/AttachmentFileCommandService.java
+++ b/src/main/java/com/careerfit/attachmentfile/service/AttachmentFileCommandService.java
@@ -4,8 +4,8 @@ import com.careerfit.application.domain.Application;
 import com.careerfit.application.exception.ApplicationErrorCode;
 import com.careerfit.application.service.ApplicationFinder;
 import com.careerfit.attachmentfile.domain.AttachmentFile;
+import com.careerfit.attachmentfile.domain.AttachmentFileType;
 import com.careerfit.attachmentfile.repository.AttachmentFileRepository;
-import com.careerfit.document.domain.DocumentType;
 import com.careerfit.document.exception.DocumentErrorCode;
 import com.careerfit.global.exception.ApplicationException;
 import com.careerfit.global.util.DocumentUtil;
@@ -24,7 +24,7 @@ public class AttachmentFileCommandService {
 
     // 파일 메타 데이터 저장
     public void saveFile(Long requestApplicationId, String uniqueFileName,
-        DocumentType documentType) {
+        AttachmentFileType attachmentFileType) {
 
         Long applicationId = DocumentUtil.extractApplicationId(uniqueFileName);
         String documentTitle = DocumentUtil.extractDocumentTitle(uniqueFileName);
@@ -38,10 +38,10 @@ public class AttachmentFileCommandService {
         Application application = applicationFinder.getApplicationOrThrow(applicationId);
         AttachmentFile attachmentFile;
 
-        if (documentType.equals(DocumentType.RESUME)) {
+        if (attachmentFileType.equals(AttachmentFileType.RESUME)) {
             attachmentFile = AttachmentFile.createResume(originalFileName, uniqueFileName,
                 documentTitle, application);
-        } else if (documentType.equals(DocumentType.PORTFOLIO)) {
+        } else if (attachmentFileType.equals(AttachmentFileType.PORTFOLIO)) {
             attachmentFile = AttachmentFile.createPortfolio(originalFileName, uniqueFileName,
                 documentTitle, application);
         } else {

--- a/src/main/java/com/careerfit/attachmentfile/service/AttachmentFileCommandService.java
+++ b/src/main/java/com/careerfit/attachmentfile/service/AttachmentFileCommandService.java
@@ -23,7 +23,8 @@ public class AttachmentFileCommandService {
     private final ApplicationFinder applicationFinder;
 
     // 파일 메타 데이터 저장
-    public void saveFile(Long requestApplicationId, String uniqueFileName, DocumentType documentType) {
+    public void saveFile(Long requestApplicationId, String uniqueFileName,
+        DocumentType documentType) {
 
         Long applicationId = DocumentUtil.extractApplicationId(uniqueFileName);
         String documentTitle = DocumentUtil.extractDocumentTitle(uniqueFileName);
@@ -37,13 +38,13 @@ public class AttachmentFileCommandService {
         Application application = applicationFinder.getApplicationOrThrow(applicationId);
         AttachmentFile attachmentFile;
 
-        if(documentType.equals(DocumentType.RESUME)){
+        if (documentType.equals(DocumentType.RESUME)) {
             attachmentFile = AttachmentFile.createResume(originalFileName, uniqueFileName,
                 documentTitle, application);
-        }else if(documentType.equals(DocumentType.PORTFOLIO)){
+        } else if (documentType.equals(DocumentType.PORTFOLIO)) {
             attachmentFile = AttachmentFile.createPortfolio(originalFileName, uniqueFileName,
                 documentTitle, application);
-        }else{
+        } else {
             throw new ApplicationException(DocumentErrorCode.DOCUMENT_INVALID_TYPE);
         }
 

--- a/src/main/java/com/careerfit/attachmentfile/service/AttachmentFileQueryService.java
+++ b/src/main/java/com/careerfit/attachmentfile/service/AttachmentFileQueryService.java
@@ -4,14 +4,15 @@ import com.careerfit.attachmentfile.domain.AttachmentFile;
 import com.careerfit.attachmentfile.dto.FileInfoResponse;
 import com.careerfit.attachmentfile.repository.AttachmentFileRepository;
 import com.careerfit.document.domain.DocumentType;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly=true)
+@Transactional(readOnly = true)
 public class AttachmentFileQueryService {
 
     private final AttachmentFileRepository attachmentFileRepository;
@@ -27,11 +28,10 @@ public class AttachmentFileQueryService {
     }
 
     // 리스트 조회
-    public List<FileInfoResponse> getFileInfoList(Long applicationId, DocumentType documentType) {
-        return attachmentFileRepository.findAllByApplicationId(applicationId)
-            .stream()
-            .filter(each -> each.getAttachmentFileType().equals(documentType))
-            .map(FileInfoResponse::fromAttachmentFile)
-            .toList();
+    public Page<FileInfoResponse> getFileInfoList(Long applicationId, DocumentType documentType,
+        Pageable pageable) {
+        return attachmentFileRepository.findAllByApplicationIdAndAttachmentFileType(applicationId,
+                documentType, pageable)
+            .map(FileInfoResponse::fromAttachmentFile);
     }
 }

--- a/src/main/java/com/careerfit/attachmentfile/service/AttachmentFileQueryService.java
+++ b/src/main/java/com/careerfit/attachmentfile/service/AttachmentFileQueryService.java
@@ -1,9 +1,9 @@
 package com.careerfit.attachmentfile.service;
 
 import com.careerfit.attachmentfile.domain.AttachmentFile;
+import com.careerfit.attachmentfile.domain.AttachmentFileType;
 import com.careerfit.attachmentfile.dto.FileInfoResponse;
 import com.careerfit.attachmentfile.repository.AttachmentFileRepository;
-import com.careerfit.document.domain.DocumentType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -28,10 +28,10 @@ public class AttachmentFileQueryService {
     }
 
     // 리스트 조회
-    public Page<FileInfoResponse> getFileInfoList(Long applicationId, DocumentType documentType,
+    public Page<FileInfoResponse> getFileInfoList(Long applicationId, AttachmentFileType attachmentFileType,
         Pageable pageable) {
         return attachmentFileRepository.findAllByApplicationIdAndAttachmentFileType(applicationId,
-                documentType, pageable)
+                attachmentFileType, pageable)
             .map(FileInfoResponse::fromAttachmentFile);
     }
 }

--- a/src/main/java/com/careerfit/attachmentfile/service/S3CommandService.java
+++ b/src/main/java/com/careerfit/attachmentfile/service/S3CommandService.java
@@ -7,9 +7,9 @@ import static com.careerfit.global.util.DocumentUtil.PORTFOLIO_PREFIX;
 import static com.careerfit.global.util.DocumentUtil.RESUME_PREFIX;
 
 import com.careerfit.attachmentfile.domain.AttachmentFile;
+import com.careerfit.attachmentfile.domain.AttachmentFileType;
 import com.careerfit.attachmentfile.dto.FileUploadRequest;
 import com.careerfit.attachmentfile.dto.PutPresignedUrlResponse;
-import com.careerfit.document.domain.DocumentType;
 import com.careerfit.global.config.AwsProperties;
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -37,12 +37,12 @@ public class S3CommandService {
     // 파일 업로드
     public PutPresignedUrlResponse generatePutPresignedUrl(
         Long applicationId,
-        DocumentType documentType,
+        AttachmentFileType attachmentFileType,
         FileUploadRequest fileUploadRequest
     ) {
         Duration expiryTime = Duration.ofMinutes(awsProperties.s3().expiryTime());
 
-        String uniqueFileName = generateUniqueFileName(applicationId, documentType,
+        String uniqueFileName = generateUniqueFileName(applicationId, attachmentFileType,
             fileUploadRequest.documentTitle(), fileUploadRequest.fileName());
 
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()
@@ -83,16 +83,16 @@ public class S3CommandService {
     // applications/{applicationId}/attachment-files/uuid_documentTitle_originalFileName
     private String generateUniqueFileName(
         Long applicationId,
-        DocumentType documentType,
+        AttachmentFileType attachmentFileType,
         String documentTitle,
         String originalFileName) {
 
         String uuid = UUID.randomUUID().toString();
         String result = APPLICATION_PREFIX + PATH_SEPARATOR + applicationId + PATH_SEPARATOR;
 
-        if (documentType.equals(DocumentType.PORTFOLIO)) {
+        if (attachmentFileType.equals(AttachmentFileType.PORTFOLIO)) {
             result += PORTFOLIO_PREFIX;
-        } else if (documentType.equals(DocumentType.RESUME)) {
+        } else if (attachmentFileType.equals(AttachmentFileType.RESUME)) {
             result += RESUME_PREFIX;
         }
 

--- a/src/main/java/com/careerfit/attachmentfile/service/S3CommandService.java
+++ b/src/main/java/com/careerfit/attachmentfile/service/S3CommandService.java
@@ -40,7 +40,7 @@ public class S3CommandService {
         DocumentType documentType,
         FileUploadRequest fileUploadRequest
     ) {
-        Duration expiryTime = Duration.ofMinutes(5);
+        Duration expiryTime = Duration.ofMinutes(awsProperties.s3().expiryTime());
 
         String uniqueFileName = generateUniqueFileName(applicationId, documentType,
             fileUploadRequest.documentTitle(), fileUploadRequest.fileName());

--- a/src/main/java/com/careerfit/attachmentfile/service/S3QueryService.java
+++ b/src/main/java/com/careerfit/attachmentfile/service/S3QueryService.java
@@ -26,7 +26,7 @@ public class S3QueryService {
     public GetPresignedUrlResponse generateGetPresignedUrl(Long applicationid,
         Long attachmentFileId) {
 
-        Duration expiryTime = Duration.ofMinutes(5);
+        Duration expiryTime = Duration.ofMillis(awsProperties.s3().expiryTime());
 
         AttachmentFile attachmentFile = attachmentFileFinder.findAttachmentFileOrThrow(
             attachmentFileId);

--- a/src/main/java/com/careerfit/comment/controller/CommentApiController.java
+++ b/src/main/java/com/careerfit/comment/controller/CommentApiController.java
@@ -8,11 +8,19 @@ import com.careerfit.comment.service.CommentQueryService;
 import com.careerfit.global.dto.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -50,12 +58,14 @@ public class CommentApiController {
 
     // comment 리스트 조회: document에 작성된 comment 리스트 조회(member 검증 로직은 아직 추가 x)
     @GetMapping("/list")
-    public ResponseEntity<ApiResponse<List<CommentInfoResponse>>> getCommentList(
+    public ResponseEntity<ApiResponse<Page<CommentInfoResponse>>> getCommentList(
         @PathVariable Long documentId,
         // TODO: 로그인 적용 시 @AuthenticationPrincipal로 변경 예정
-        @RequestParam Long memberId
+        @RequestParam Long memberId,
+        Pageable pageable
     ) {
-        List<CommentInfoResponse> response = commentQueryService.findAllComment(documentId, memberId);
+        Page<CommentInfoResponse> response = commentQueryService.findAllComment(documentId,
+            memberId, pageable);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
@@ -68,7 +78,8 @@ public class CommentApiController {
         @RequestParam Long memberId,
         @Valid @RequestBody CommentUpdateRequest request
     ) {
-        CommentInfoResponse response = commentCommandService.updateComment(commentId, memberId, request);
+        CommentInfoResponse response = commentCommandService.updateComment(commentId, memberId,
+            request);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/careerfit/comment/domain/Coordinate.java
+++ b/src/main/java/com/careerfit/comment/domain/Coordinate.java
@@ -1,15 +1,19 @@
 package com.careerfit.comment.domain;
 
 import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Embeddable
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class Coordinate {
 
-    private int startX;
-    private int startY;
-    private int endX;
-    private int endY;
+    private Double startX;
+    private Double startY;
+    private Double endX;
+    private Double endY;
 
 }

--- a/src/main/java/com/careerfit/comment/repository/CommentRepository.java
+++ b/src/main/java/com/careerfit/comment/repository/CommentRepository.java
@@ -1,12 +1,13 @@
 package com.careerfit.comment.repository;
 
 import com.careerfit.comment.domain.Comment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-    List<Comment> findAllByDocumentId(Long documentId);
+
+    Page<Comment> findAllByDocumentId(Long documentId, Pageable pageable);
 }

--- a/src/main/java/com/careerfit/comment/service/CommentQueryService.java
+++ b/src/main/java/com/careerfit/comment/service/CommentQueryService.java
@@ -4,10 +4,10 @@ import com.careerfit.comment.domain.Comment;
 import com.careerfit.comment.dto.CommentInfoResponse;
 import com.careerfit.comment.repository.CommentRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -25,12 +25,11 @@ public class CommentQueryService {
         return CommentInfoResponse.from(comment);
     }
 
-    public List<CommentInfoResponse> findAllComment(Long documentId, Long memberId) {
+    public Page<CommentInfoResponse> findAllComment(Long documentId, Long memberId,
+        Pageable pageable) {
         // 멘토나, 해당 문서를 소유한 멘티만 해당 코멘트 리스트를 조회할 수 있도록 검증 로직 추가 필요: 이후 추가 예정
 
-        return commentRepository.findAllByDocumentId(documentId)
-            .stream()
-            .map(CommentInfoResponse::from)
-            .toList();
+        return commentRepository.findAllByDocumentId(documentId, pageable)
+            .map(CommentInfoResponse::from);
     }
 }

--- a/src/main/java/com/careerfit/document/domain/DocumentType.java
+++ b/src/main/java/com/careerfit/document/domain/DocumentType.java
@@ -1,5 +1,5 @@
 package com.careerfit.document.domain;
 
 public enum DocumentType {
-    COVER_LETTER, ATTACHMENT_FILE, RESUME, PORTFOLIO
+    COVER_LETTER, ATTACHMENT_FILE
 }

--- a/src/main/java/com/careerfit/global/config/AwsProperties.java
+++ b/src/main/java/com/careerfit/global/config/AwsProperties.java
@@ -2,6 +2,7 @@ package com.careerfit.global.config;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
@@ -23,17 +24,23 @@ public record AwsProperties(
         @NotBlank(message = "AWS secretKey가 비어있습니다.")
         String secretKey
     ) {
+
     }
 
     public record S3(
         @NotBlank(message = "AWS bucket이 비어있습니다.")
-        String bucket
+        String bucket,
+
+        @NotNull(message = "expiryTime이 비어있습니다.")
+        Long expiryTime
     ) {
+
     }
 
     public record Region(
         @NotBlank(message = "AWS region이 비어있습니다.")
         String regionValue
     ) {
+
     }
 }

--- a/src/main/java/com/careerfit/global/initializer/DataInitializer.java
+++ b/src/main/java/com/careerfit/global/initializer/DataInitializer.java
@@ -4,6 +4,7 @@ import com.careerfit.application.domain.Application;
 import com.careerfit.application.domain.ApplicationStatus;
 import com.careerfit.application.repository.ApplicationJpaRepository;
 import com.careerfit.attachmentfile.domain.AttachmentFile;
+import com.careerfit.attachmentfile.domain.AttachmentFileType;
 import com.careerfit.auth.domain.OAuthProvider;
 import com.careerfit.comment.domain.Comment;
 import com.careerfit.comment.domain.Coordinate;
@@ -138,32 +139,36 @@ public class DataInitializer implements CommandLineRunner {
         app2.addDocument(cl2);
 
         // 5. AttachmentFile 생성 및 저장
-        AttachmentFile resume1 = AttachmentFile.createResume(
+        AttachmentFile resume1 = AttachmentFile.of(
             "resume1.pdf",
             "applications/" + app1.getId() + "/resumes/" + UUID.randomUUID() + "_resume1_resume1.pdf",
             "resume1",
-            app1
+            app1,
+            AttachmentFileType.RESUME
         );
-        AttachmentFile portfolio1 = AttachmentFile.createPortfolio(
+        AttachmentFile portfolio1 = AttachmentFile.of(
             "portfolio1.pdf",
             "applications/" + app1.getId() + "/portfolios/" + UUID.randomUUID() + "_portfolio1_portfolio1.pdf",
             "portfolio1",
-            app1
+            app1,
+            AttachmentFileType.PORTFOLIO
         );
         app1.addDocument(resume1);
         app1.addDocument(portfolio1);
 
-        AttachmentFile resume2 = AttachmentFile.createResume(
+        AttachmentFile resume2 = AttachmentFile.of(
             "resume2.pdf",
             "applications/" + app2.getId() + "/resumes/" + UUID.randomUUID() + "_resume2_resume2.pdf",
             "resume2",
-            app2
+            app2,
+            AttachmentFileType.RESUME
         );
-        AttachmentFile portfolio2 = AttachmentFile.createPortfolio(
+        AttachmentFile portfolio2 = AttachmentFile.of(
             "portfolio2.pdf",
             "applications/" + app2.getId() + "/portfolios/" + UUID.randomUUID() + "_portfolio2_portfolio2.pdf",
             "portfolio2",
-            app2
+            app2,
+            AttachmentFileType.PORTFOLIO
         );
         app2.addDocument(resume2);
         app2.addDocument(portfolio2);

--- a/src/main/java/com/careerfit/global/initializer/DataInitializer.java
+++ b/src/main/java/com/careerfit/global/initializer/DataInitializer.java
@@ -3,7 +3,12 @@ package com.careerfit.global.initializer;
 import com.careerfit.application.domain.Application;
 import com.careerfit.application.domain.ApplicationStatus;
 import com.careerfit.application.repository.ApplicationJpaRepository;
+import com.careerfit.attachmentfile.domain.AttachmentFile;
 import com.careerfit.auth.domain.OAuthProvider;
+import com.careerfit.comment.domain.Comment;
+import com.careerfit.comment.domain.Coordinate;
+import com.careerfit.comment.dto.CommentCreateRequest;
+import com.careerfit.comment.repository.CommentRepository;
 import com.careerfit.coverletter.domain.CoverLetter;
 import com.careerfit.coverletter.domain.CoverLetterItem;
 import com.careerfit.member.domain.Member;
@@ -21,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Component
 @Profile({"local", "prod"})
@@ -29,6 +35,7 @@ public class DataInitializer implements CommandLineRunner {
 
     private final MemberJpaRepository memberRepository;
     private final ApplicationJpaRepository applicationRepository;
+    private final CommentRepository commentRepository;
 
     @Override
     @Transactional
@@ -129,6 +136,53 @@ public class DataInitializer implements CommandLineRunner {
         CoverLetter cl2 = CoverLetter.createCoverLetter("라인 신입 백엔드 개발자 자기소개서2", items2);
         app1.addDocument(cl1);
         app2.addDocument(cl2);
+
+        // 5. AttachmentFile 생성 및 저장
+        AttachmentFile resume1 = AttachmentFile.createResume(
+            "resume1.pdf",
+            "applications/" + app1.getId() + "/resumes/" + UUID.randomUUID() + "_resume1_resume1.pdf",
+            "resume1",
+            app1
+        );
+        AttachmentFile portfolio1 = AttachmentFile.createPortfolio(
+            "portfolio1.pdf",
+            "applications/" + app1.getId() + "/portfolios/" + UUID.randomUUID() + "_portfolio1_portfolio1.pdf",
+            "portfolio1",
+            app1
+        );
+        app1.addDocument(resume1);
+        app1.addDocument(portfolio1);
+
+        AttachmentFile resume2 = AttachmentFile.createResume(
+            "resume2.pdf",
+            "applications/" + app2.getId() + "/resumes/" + UUID.randomUUID() + "_resume2_resume2.pdf",
+            "resume2",
+            app2
+        );
+        AttachmentFile portfolio2 = AttachmentFile.createPortfolio(
+            "portfolio2.pdf",
+            "applications/" + app2.getId() + "/portfolios/" + UUID.randomUUID() + "_portfolio2_portfolio2.pdf",
+            "portfolio2",
+            app2
+        );
+        app2.addDocument(resume2);
+        app2.addDocument(portfolio2);
+
+        // 6. Comment 생성 및 저장
+        List<Comment> comments = new ArrayList<>();
+        comments.add(Comment.of(cl1, mento1, new CommentCreateRequest("댓글1", new Coordinate(10.0, 10.0, 20.0, 20.0))));
+        comments.add(Comment.of(cl1, mentee1, new CommentCreateRequest("댓글2", new Coordinate(10.0, 10.0, 20.0, 20.0))));
+        comments.add(Comment.of(cl2, mento2, new CommentCreateRequest("댓글3", new Coordinate(15.0, 15.0, 25.0, 25.0))));
+        comments.add(Comment.of(cl2, mentee2, new CommentCreateRequest("댓글4", new Coordinate(15.0, 15.0, 25.0, 25.0))));
+        comments.add(Comment.of(resume1, mento1, new CommentCreateRequest("댓글5", new Coordinate(20.0, 20.0, 30.0, 30.0))));
+        comments.add(Comment.of(resume1, mentee1, new CommentCreateRequest("댓글6", new Coordinate(20.0, 20.0, 30.0, 30.0))));
+        comments.add(Comment.of(portfolio1, mento1, new CommentCreateRequest("댓글7", new Coordinate(25.0, 25.0, 35.0, 35.0))));
+        comments.add(Comment.of(portfolio1, mentee1, new CommentCreateRequest("댓글8", new Coordinate(25.0, 25.0, 35.0, 35.0))));
+        comments.add(Comment.of(resume2, mento2, new CommentCreateRequest("댓글9", new Coordinate(30.0, 30.0, 40.0, 40.0))));
+        comments.add(Comment.of(resume2, mentee2, new CommentCreateRequest("댓글10", new Coordinate(30.0, 30.0, 40.0, 40.0))));
+        comments.add(Comment.of(portfolio2, mento2, new CommentCreateRequest("댓글11", new Coordinate(35.0, 35.0, 45.0, 45.0))));
+        comments.add(Comment.of(portfolio2, mentee2, new CommentCreateRequest("댓글12", new Coordinate(35.0, 35.0, 45.0, 45.0))));
+        commentRepository.saveAll(comments);
 
         System.out.println("====== 더미 데이터 생성 완료 ======");
     }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -10,7 +10,7 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
     properties:
       hibernate:
         format_sql: true

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -10,7 +10,7 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true
@@ -34,5 +34,7 @@ cloud:
       secret-key: ${S3_SECRET_KEY}
     s3:
       bucket: ${S3_BUCKET_NAME}
+      # 5 minutes
+      expiry-time: ${EXPIRY_TIME}
     region:
       region-value: ap-northeast-2

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -34,5 +34,7 @@ cloud:
       secret-key: ${S3_SECRET_KEY}
     s3:
       bucket: ${S3_BUCKET_NAME}
+      # 5 minutes
+      expiry-time: ${EXPIRY_TIME}
     region:
       region-value: ap-northeast-2

--- a/src/test/java/com/careerfit/AttachmentFile/service/AttachmentFileCommandServiceTest.java
+++ b/src/test/java/com/careerfit/AttachmentFile/service/AttachmentFileCommandServiceTest.java
@@ -10,11 +10,11 @@ import com.careerfit.application.domain.Application;
 import com.careerfit.application.domain.ApplicationStatus;
 import com.careerfit.application.service.ApplicationFinder;
 import com.careerfit.attachmentfile.domain.AttachmentFile;
+import com.careerfit.attachmentfile.domain.AttachmentFileType;
 import com.careerfit.attachmentfile.repository.AttachmentFileRepository;
 import com.careerfit.attachmentfile.service.AttachmentFileCommandService;
 import com.careerfit.attachmentfile.service.AttachmentFileFinder;
 import com.careerfit.auth.domain.OAuthProvider;
-import com.careerfit.document.domain.DocumentType;
 import com.careerfit.global.util.DocumentUtil;
 import com.careerfit.member.domain.Member;
 import com.careerfit.member.domain.mentee.MenteeProfile;
@@ -82,7 +82,7 @@ class AttachmentFileCommandServiceTest {
             .originalFileName("MyResume")
             .storedFilePath("applications/1/resumes/a42f8cd9-7391-437d-91ef-9b78e462db9c_MyResume1_MyResume")
             .title("MyResume1")
-            .attachmentFileType(DocumentType.RESUME)
+            .attachmentFileType(AttachmentFileType.RESUME)
             .build();
         app1.addDocument(file1);
 
@@ -91,7 +91,7 @@ class AttachmentFileCommandServiceTest {
             .originalFileName("MyPortfolio")
             .storedFilePath("applications/1/portfolios/a42f8cd9-7391-437d-91ef-9b78e462db9c_MyPortfolio1_MyPortfolio")
             .title("MyPortfolio1")
-            .attachmentFileType(DocumentType.PORTFOLIO)
+            .attachmentFileType(AttachmentFileType.PORTFOLIO)
             .build();
         app2.addDocument(file2);
 
@@ -100,7 +100,7 @@ class AttachmentFileCommandServiceTest {
             .originalFileName("MyResumeV2")
             .storedFilePath("applications/1/resumes/a42f8cd9-7391-437d-91ef-9b78e462db9c_MyResume2_MyResumeV2")
             .title("MyResume2")
-            .attachmentFileType(DocumentType.RESUME)
+            .attachmentFileType(AttachmentFileType.RESUME)
             .build();
         app1.addDocument(file3);
     }
@@ -127,7 +127,7 @@ class AttachmentFileCommandServiceTest {
         // 실제 파일 메타 데이터 저장
         // given
         Long requestApplicationId = 1L;
-        DocumentType documentType = DocumentType.RESUME;
+        AttachmentFileType documentType = AttachmentFileType.RESUME;
         when(applicationFinder.getApplicationOrThrow(extractedApplicationId)).thenReturn(app1);
         ArgumentCaptor<AttachmentFile> attachmentFileCaptor = ArgumentCaptor.forClass(AttachmentFile.class);
 

--- a/src/test/java/com/careerfit/AttachmentFile/service/AttachmentFileQueryServiceTest.java
+++ b/src/test/java/com/careerfit/AttachmentFile/service/AttachmentFileQueryServiceTest.java
@@ -6,12 +6,12 @@ import static org.mockito.Mockito.when;
 import com.careerfit.application.domain.Application;
 import com.careerfit.application.domain.ApplicationStatus;
 import com.careerfit.attachmentfile.domain.AttachmentFile;
+import com.careerfit.attachmentfile.domain.AttachmentFileType;
 import com.careerfit.attachmentfile.dto.FileInfoResponse;
 import com.careerfit.attachmentfile.repository.AttachmentFileRepository;
 import com.careerfit.attachmentfile.service.AttachmentFileFinder;
 import com.careerfit.attachmentfile.service.AttachmentFileQueryService;
 import com.careerfit.auth.domain.OAuthProvider;
-import com.careerfit.document.domain.DocumentType;
 import com.careerfit.member.domain.Member;
 import com.careerfit.member.domain.mentee.MenteeProfile;
 import com.careerfit.member.domain.mentee.MenteeWishCompany;
@@ -77,7 +77,7 @@ class AttachmentFileQueryServiceTest {
             .originalFileName("이력서.pdf")
             .storedFilePath("resumes/uuid-resume.pdf")
             .title("김철수 이력서")
-            .attachmentFileType(DocumentType.RESUME)
+            .attachmentFileType(AttachmentFileType.RESUME)
             .build();
         app1.addDocument(file1);
 
@@ -86,7 +86,7 @@ class AttachmentFileQueryServiceTest {
             .originalFileName("포트폴리오.pdf")
             .storedFilePath("portfolios/uuid-portfolio.pdf")
             .title("박영희 포트폴리오")
-            .attachmentFileType(DocumentType.PORTFOLIO)
+            .attachmentFileType(AttachmentFileType.PORTFOLIO)
             .build();
         app2.addDocument(file2);
 
@@ -95,7 +95,7 @@ class AttachmentFileQueryServiceTest {
             .originalFileName("이력서_수정본.pdf")
             .storedFilePath("resumes/uuid-resume-v2.pdf")
             .title("김철수 이력서 수정")
-            .attachmentFileType(DocumentType.RESUME)
+            .attachmentFileType(AttachmentFileType.RESUME)
             .application(app1)
             .build();
         app1.addDocument(file3);
@@ -119,7 +119,7 @@ class AttachmentFileQueryServiceTest {
         assertThat(response.id()).isEqualTo(1L);
         assertThat(response.applicationId()).isEqualTo(1L);
         assertThat(response.originalFileName()).isEqualTo("이력서.pdf");
-        assertThat(response.attachmentFileType()).isEqualTo(DocumentType.RESUME);
+        assertThat(response.attachmentFileType()).isEqualTo(AttachmentFileType.RESUME);
     }
 
     @Test
@@ -127,7 +127,7 @@ class AttachmentFileQueryServiceTest {
     void getFileInfoList() {
         // given
         Long applicationId = 1L;
-        DocumentType documentType = DocumentType.RESUME;
+        AttachmentFileType documentType = AttachmentFileType.RESUME;
         Pageable pageable = PageRequest.of(0, 2);
 
         List<AttachmentFile> resumeFiles = app1.getDocuments().stream()

--- a/src/test/java/com/careerfit/AttachmentFile/service/AttachmentFileQueryServiceTest.java
+++ b/src/test/java/com/careerfit/AttachmentFile/service/AttachmentFileQueryServiceTest.java
@@ -27,6 +27,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 @ExtendWith(MockitoExtension.class)
 class AttachmentFileQueryServiceTest {
@@ -126,25 +130,29 @@ class AttachmentFileQueryServiceTest {
         // given
         Long applicationId = 1L;
         DocumentType documentType = DocumentType.RESUME;
-        when(attachmentFileRepository.findAllByApplicationId(applicationId))
-            .thenReturn(app1.getDocuments().stream()
-                .filter(each -> each instanceof AttachmentFile)
-                .map(each -> (AttachmentFile) each)
-                .toList());
+        Pageable pageable = PageRequest.of(0, 2);
+
+        List<AttachmentFile> resumeFiles = app1.getDocuments().stream()
+            .filter(doc -> doc instanceof AttachmentFile)
+            .map(doc -> (AttachmentFile) doc)
+            .filter(file -> documentType.equals(file.getAttachmentFileType()))
+            .toList();
+        Page<AttachmentFile> pagedResponse = new PageImpl<>(resumeFiles, pageable, resumeFiles.size());
+
+        when(attachmentFileRepository.findAllByApplicationIdAndAttachmentFileType(applicationId, documentType, pageable))
+            .thenReturn(pagedResponse);
 
         // when
-        List<FileInfoResponse> response = attachmentFileQueryService.getFileInfoList(applicationId,
-            documentType);
+        Page<FileInfoResponse> response = attachmentFileQueryService.getFileInfoList(applicationId, documentType, pageable);
 
         // then
         assertThat(response).isNotNull();
-        assertThat(response).hasSize(2);
-        assertThat(response).extracting(FileInfoResponse::id)
+        assertThat(response.getTotalElements()).isEqualTo(2);
+        assertThat(response.getContent()).hasSize(2);
+        assertThat(response.getContent()).extracting(FileInfoResponse::id)
             .containsExactlyInAnyOrder(1L, 3L);
-        assertThat(response).extracting(FileInfoResponse::attachmentFileType)
+        assertThat(response.getContent()).extracting(FileInfoResponse::attachmentFileType)
             .allMatch(type -> type.equals(documentType));
-        assertThat(response.get(0).originalFileName()).isEqualTo(file1.getOriginalFileName());
-        assertThat(response.get(1).originalFileName()).isEqualTo(file3.getOriginalFileName());
     }
 
 

--- a/src/test/java/com/careerfit/AttachmentFile/service/AttachmentFileQueryServiceTest.java
+++ b/src/test/java/com/careerfit/AttachmentFile/service/AttachmentFileQueryServiceTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.when;
 
 import com.careerfit.application.domain.Application;
 import com.careerfit.application.domain.ApplicationStatus;
-import com.careerfit.application.service.ApplicationFinder;
 import com.careerfit.attachmentfile.domain.AttachmentFile;
 import com.careerfit.attachmentfile.dto.FileInfoResponse;
 import com.careerfit.attachmentfile.repository.AttachmentFileRepository;
@@ -17,7 +16,6 @@ import com.careerfit.member.domain.Member;
 import com.careerfit.member.domain.mentee.MenteeProfile;
 import com.careerfit.member.domain.mentee.MenteeWishCompany;
 import com.careerfit.member.domain.mentee.MenteeWishPosition;
-
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -137,13 +135,16 @@ class AttachmentFileQueryServiceTest {
             .map(doc -> (AttachmentFile) doc)
             .filter(file -> documentType.equals(file.getAttachmentFileType()))
             .toList();
-        Page<AttachmentFile> pagedResponse = new PageImpl<>(resumeFiles, pageable, resumeFiles.size());
+        Page<AttachmentFile> pagedResponse = new PageImpl<>(resumeFiles, pageable,
+            resumeFiles.size());
 
-        when(attachmentFileRepository.findAllByApplicationIdAndAttachmentFileType(applicationId, documentType, pageable))
+        when(attachmentFileRepository.findAllByApplicationIdAndAttachmentFileType(applicationId,
+            documentType, pageable))
             .thenReturn(pagedResponse);
 
         // when
-        Page<FileInfoResponse> response = attachmentFileQueryService.getFileInfoList(applicationId, documentType, pageable);
+        Page<FileInfoResponse> response = attachmentFileQueryService.getFileInfoList(applicationId,
+            documentType, pageable);
 
         // then
         assertThat(response).isNotNull();

--- a/src/test/java/com/careerfit/attachmentfile/service/AttachmentFileCommandServiceTest.java
+++ b/src/test/java/com/careerfit/attachmentfile/service/AttachmentFileCommandServiceTest.java
@@ -1,4 +1,4 @@
-package com.careerfit.AttachmentFile.service;
+package com.careerfit.attachmentfile.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doNothing;
@@ -12,8 +12,6 @@ import com.careerfit.application.service.ApplicationFinder;
 import com.careerfit.attachmentfile.domain.AttachmentFile;
 import com.careerfit.attachmentfile.domain.AttachmentFileType;
 import com.careerfit.attachmentfile.repository.AttachmentFileRepository;
-import com.careerfit.attachmentfile.service.AttachmentFileCommandService;
-import com.careerfit.attachmentfile.service.AttachmentFileFinder;
 import com.careerfit.auth.domain.OAuthProvider;
 import com.careerfit.global.util.DocumentUtil;
 import com.careerfit.member.domain.Member;

--- a/src/test/java/com/careerfit/attachmentfile/service/AttachmentFileQueryServiceTest.java
+++ b/src/test/java/com/careerfit/attachmentfile/service/AttachmentFileQueryServiceTest.java
@@ -1,4 +1,4 @@
-package com.careerfit.AttachmentFile.service;
+package com.careerfit.attachmentfile.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -9,8 +9,6 @@ import com.careerfit.attachmentfile.domain.AttachmentFile;
 import com.careerfit.attachmentfile.domain.AttachmentFileType;
 import com.careerfit.attachmentfile.dto.FileInfoResponse;
 import com.careerfit.attachmentfile.repository.AttachmentFileRepository;
-import com.careerfit.attachmentfile.service.AttachmentFileFinder;
-import com.careerfit.attachmentfile.service.AttachmentFileQueryService;
 import com.careerfit.auth.domain.OAuthProvider;
 import com.careerfit.member.domain.Member;
 import com.careerfit.member.domain.mentee.MenteeProfile;


### PR DESCRIPTION
## 📄Summary
- AttachmentFile, Comments의 리스트 조회 API에 페이지네이션을 적용했습니다.
- 이전 PR에서 받은 리뷰를 반영해서 AttachmentFileType을 생성 및 AttachmentFile 생성 정적 팩토리 메서드를 of()로 통일했습니다.

<br><br>

## 🙋🏻 More
- S3 업로드/조회에 필요한 presignedUrl의 유효기간을 환경변수에서 설정할 수 있도록 변경했습니다. 디코에 환경변수 공유해놓겠습니다.

<br><br>

## 🔗관련 이슈
- Close #69 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added pagination to attachment file lists and comment lists for faster browsing.
  - Enabled filtering attachment files by type (e.g., resume, portfolio) in list views.
- Improvements
  - Presigned URL expiration is now configurable, replacing the fixed 5-minute window.
  - Comment coordinates now support decimal values for more precise annotations.
- Chores
  - Updated local and production configs to include S3 URL expiry settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->