### PR TITLE
첨부파일(이력서/포트폴리오), 댓글 API swagger 설정 추가

### DIFF
--- a/src/main/java/com/careerfit/attachmentfile/controller/AttachmentFileApiController.java
+++ b/src/main/java/com/careerfit/attachmentfile/controller/AttachmentFileApiController.java
@@ -28,7 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/applications/{application-id}/attachment-files")
-public class AttachmentFileApiController {
+public class AttachmentFileApiController implements AttachmentFileApiDocs{
 
     private final S3QueryService s3QueryService;
     private final S3CommandService s3CommandService;
@@ -39,9 +39,10 @@ public class AttachmentFileApiController {
 
     // 파일 업로드
     @PostMapping("/file-upload")
+    @Override
     public ResponseEntity<ApiResponse<PutPresignedUrlResponse>> generatePostPresignedUrl(
         @PathVariable(name = "application-id") Long applicationId,
-        @RequestParam(name = "document-type") AttachmentFileType attachmentFileType,
+        @RequestParam(name = "attachment-file-type") AttachmentFileType attachmentFileType,
         @Valid @RequestBody FileUploadRequest request
     ) {
         PutPresignedUrlResponse response = s3CommandService.generatePutPresignedUrl(applicationId,
@@ -52,6 +53,7 @@ public class AttachmentFileApiController {
 
     // 파일 조회
     @GetMapping("/{attachment-file-id}")
+    @Override
     public ResponseEntity<ApiResponse<GetPresignedUrlResponse>> generateGetPresignedUrl(
         @PathVariable(name = "application-id") Long applicationId,
         @PathVariable(name = "attachment-file-id") Long attachmentFileId
@@ -63,6 +65,7 @@ public class AttachmentFileApiController {
 
     // 파일 삭제
     @DeleteMapping("/{attachment-file-id}")
+    @Override
     public ResponseEntity<ApiResponse<Void>> deleteFile(
         @PathVariable(name = "application-id") Long applicationId,
         @PathVariable(name = "attachment-file-id") Long attachmentFileId
@@ -77,6 +80,7 @@ public class AttachmentFileApiController {
 
     // 파일 메타 데이터 단건 조회
     @GetMapping("/{attachment-file-id}/metadata")
+    @Override
     public ResponseEntity<ApiResponse<FileInfoResponse>> getFileMetaData(
         @PathVariable(name = "application-id") Long applicationId,
         @PathVariable(name = "attachment-file-id") Long attachmentFileId
@@ -88,9 +92,10 @@ public class AttachmentFileApiController {
 
     // 파일 메타 데이터 리스트 조회
     @GetMapping("/metadata/list")
+    @Override
     public ResponseEntity<ApiResponse<Page<FileInfoResponse>>> getFileMetaDataList(
         @PathVariable(name = "application-id") Long applicationId,
-        @RequestParam(name = "document-type") AttachmentFileType attachmentFileType,
+        @RequestParam(name = "attachment-file-type") AttachmentFileType attachmentFileType,
         Pageable pageable
     ) {
         Page<FileInfoResponse> response = attachmentFileQueryService.getFileInfoList(applicationId,

--- a/src/main/java/com/careerfit/attachmentfile/controller/AttachmentFileApiDocs.java
+++ b/src/main/java/com/careerfit/attachmentfile/controller/AttachmentFileApiDocs.java
@@ -1,0 +1,113 @@
+package com.careerfit.attachmentfile.controller;
+
+import com.careerfit.attachmentfile.domain.AttachmentFileType;
+import com.careerfit.attachmentfile.dto.FileInfoResponse;
+import com.careerfit.attachmentfile.dto.FileUploadRequest;
+import com.careerfit.attachmentfile.dto.GetPresignedUrlResponse;
+import com.careerfit.attachmentfile.dto.PutPresignedUrlResponse;
+import com.careerfit.global.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "AttachmentFile API", description = "첨부파일(이력서/포트폴리오) API 명세서")
+public interface AttachmentFileApiDocs {
+
+    @Operation(
+        summary = "파일 업로드용 url 발급",
+        description = "S3에 파일을 직접 업로드할 때 필요한 임시 URL을 발급합니다.",
+        requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "파일의 원본이름과 DB에 저장할 이름, 파일 타입 정보를 담은 객체",
+            required = true
+        )
+    )
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "presignedUrl 발급 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터")
+    })
+    ResponseEntity<ApiResponse<PutPresignedUrlResponse>> generatePostPresignedUrl(
+        @Parameter(description = "지원항목 ID", example = "1")
+        @PathVariable(name = "application-id") Long applicationId,
+
+        @Parameter(description = "첨부파일 종류 (RESUME or PORTFOLIO)", example = "RESUME")
+        @RequestParam(name = "attachment-file-type") AttachmentFileType attachmentFileType,
+
+        @Parameter
+        @Valid @RequestBody FileUploadRequest request
+    );
+
+
+    @Operation(
+        summary = "파일 조회용 url 발급",
+        description = "S3에 업로드된 파일을 조회할 때 필요한 임시 URL을 발급합니다."
+    )
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "presignedUrl 발급 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 파일을 찾을 수 없습니다.")
+    })
+    ResponseEntity<ApiResponse<GetPresignedUrlResponse>> generateGetPresignedUrl(
+        @Parameter(description = "지원항목 ID", example = "1")
+        @PathVariable(name = "application-id") Long applicationId,
+
+        @Parameter(description = "첨부파일 ID", example = "1")
+        @PathVariable(name = "attachment-file-id") Long attachmentFileId
+    );
+
+
+    @Operation(
+        summary = "파일 삭제",
+        description = "S3에 업로드된 파일과 DB 메타데이터를 삭제합니다."
+    )
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "파일 삭제 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 파일을 찾을 수 없습니다.")
+    })
+    ResponseEntity<ApiResponse<Void>> deleteFile(
+        @Parameter(description = "지원항목 ID", example = "1")
+        @PathVariable(name = "application-id") Long applicationId,
+
+        @Parameter(description = "첨부파일 ID", example = "1")
+        @PathVariable(name = "attachment-file-id") Long attachmentFileId
+    );
+
+    @Operation(
+        summary = "파일 메타데이터 단건 조회",
+        description = "첨부파일의 메타데이터(원본 파일명, 파일 크기 등)를 조회합니다."
+    )
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "메타데이터 조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 파일을 찾을 수 없습니다.")
+    })
+    ResponseEntity<ApiResponse<FileInfoResponse>> getFileMetaData(
+        @Parameter(description = "지원항목 ID", example = "1")
+        @PathVariable(name = "application-id") Long applicationId,
+
+        @Parameter(description = "첨부파일 ID", example = "1")
+        @PathVariable(name = "attachment-file-id") Long attachmentFileId
+    );
+
+    @Operation(
+        summary = "파일 메타데이터 목록 조회",
+        description = "특정 지원 항목 및 파일 종류에 해당하는 첨부파일 메타데이터 목록을 조회합니다."
+    )
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "메타데이터 목록 조회 성공")
+    })
+    ResponseEntity<ApiResponse<Page<FileInfoResponse>>> getFileMetaDataList(
+        @Parameter(description = "지원항목 ID", example = "1")
+        @PathVariable(name = "application-id") Long applicationId,
+
+        @Parameter(description = "첨부파일 종류 (RESUME or PORTFOLIO)", example = "RESUME")
+        @RequestParam(name = "attachment-file-type") AttachmentFileType attachmentFileType,
+
+        Pageable pageable
+    );
+}

--- a/src/main/java/com/careerfit/comment/controller/CommentApiController.java
+++ b/src/main/java/com/careerfit/comment/controller/CommentApiController.java
@@ -25,18 +25,19 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/documents/{documentId}/comments")
-public class CommentApiController {
+public class CommentApiController implements CommentApiDocs {
 
     private final CommentCommandService commentCommandService;
     private final CommentQueryService commentQueryService;
 
     // comment 생성
     @PostMapping
+    @Override
     public ResponseEntity<ApiResponse<Void>> createComment(
         @PathVariable Long documentId,
         // TODO: 로그인 적용 시 @AuthenticationPrincipal로 변경 예정
         @RequestParam Long memberId,
-        @RequestBody CommentCreateRequest request
+        @Valid @RequestBody CommentCreateRequest request
     ) {
         commentCommandService.createComment(documentId, memberId, request);
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -46,6 +47,7 @@ public class CommentApiController {
     // comment 단건 조회
     // 단건 조회/수정/삭제에는 documentId가 불필요하긴 하지만, 다른 API 경로와의 일관성을 위해 추가했습니다.
     @GetMapping("/{commentId}")
+    @Override
     public ResponseEntity<ApiResponse<CommentInfoResponse>> getComment(
         @PathVariable Long documentId,
         @PathVariable Long commentId,
@@ -58,6 +60,7 @@ public class CommentApiController {
 
     // comment 리스트 조회: document에 작성된 comment 리스트 조회(member 검증 로직은 아직 추가 x)
     @GetMapping("/list")
+    @Override
     public ResponseEntity<ApiResponse<Page<CommentInfoResponse>>> getCommentList(
         @PathVariable Long documentId,
         // TODO: 로그인 적용 시 @AuthenticationPrincipal로 변경 예정
@@ -71,6 +74,7 @@ public class CommentApiController {
 
     // comment 수정
     @PatchMapping("/{commentId}")
+    @Override
     public ResponseEntity<ApiResponse<CommentInfoResponse>> updateComment(
         @PathVariable Long documentId,
         @PathVariable Long commentId,
@@ -85,6 +89,7 @@ public class CommentApiController {
 
     // comment 삭제
     @DeleteMapping("/{commentId}")
+    @Override
     public ResponseEntity<Void> deleteComment(
         @PathVariable Long documentId,
         @PathVariable Long commentId,

--- a/src/main/java/com/careerfit/comment/controller/CommentApiDocs.java
+++ b/src/main/java/com/careerfit/comment/controller/CommentApiDocs.java
@@ -1,0 +1,123 @@
+package com.careerfit.comment.controller;
+
+import com.careerfit.comment.dto.CommentCreateRequest;
+import com.careerfit.comment.dto.CommentInfoResponse;
+import com.careerfit.comment.dto.CommentUpdateRequest;
+import com.careerfit.global.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Comment API", description = "댓글 API 명세서")
+public interface CommentApiDocs {
+
+    @Operation(
+        summary = "댓글 생성",
+        description = "특정 문서에 댓글을 생성합니다.",
+        requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "댓글 내용",
+            required = true
+        )
+    )
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "댓글 생성 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "문서 또는 회원을 찾을 수 없습니다.")
+    })
+    ResponseEntity<ApiResponse<Void>> createComment(
+        @Parameter(description = "문서 ID", example = "1")
+        @PathVariable Long documentId,
+
+        @Parameter(description = "회원 ID: 로그인 적용 시 @AuthenticationPrincipal로 변경할 예정", example = "1")
+        @RequestParam Long memberId,
+
+        @Valid @RequestBody CommentCreateRequest request
+    );
+
+    @Operation(
+        summary = "댓글 단건 조회",
+        description = "특정 댓글의 정보를 조회합니다."
+    )
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "댓글 조회 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "댓글을 찾을 수 없습니다.")
+    })
+    ResponseEntity<ApiResponse<CommentInfoResponse>> getComment(
+        @Parameter(description = "문서 ID", example = "1")
+        @PathVariable Long documentId,
+
+        @Parameter(description = "댓글 ID", example = "1")
+        @PathVariable Long commentId,
+
+        @Parameter(description = "회원 ID: 로그인 적용 시 @AuthenticationPrincipal로 변경할 예정", example = "1")
+        @RequestParam Long memberId
+    );
+
+    @Operation(
+        summary = "댓글 목록 조회",
+        description = "특정 문서에 달린 댓글 목록을 조회합니다."
+    )
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "댓글 목록 조회 성공")
+    })
+    ResponseEntity<ApiResponse<Page<CommentInfoResponse>>> getCommentList(
+        @Parameter(description = "문서 ID", example = "1")
+        @PathVariable Long documentId,
+
+        @Parameter(description = "회원 ID: 로그인 적용 시 @AuthenticationPrincipal로 변경할 예정", example = "1")
+        @RequestParam Long memberId,
+
+        Pageable pageable
+    );
+
+    @Operation(
+        summary = "댓글 수정",
+        description = "특정 댓글의 내용을 수정합니다.",
+        requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            description = "수정할 댓글 내용",
+            required = true
+        )
+    )
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "댓글 수정 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "댓글을 찾을 수 없습니다.")
+    })
+    ResponseEntity<ApiResponse<CommentInfoResponse>> updateComment(
+        @Parameter(description = "문서 ID", example = "1")
+        @PathVariable Long documentId,
+
+        @Parameter(description = "댓글 ID", example = "1")
+        @PathVariable Long commentId,
+
+        @Parameter(description = "회원 ID: 로그인 적용 시 @AuthenticationPrincipal로 변경할 예정", example = "1")
+        @RequestParam Long memberId,
+
+        @Valid @RequestBody CommentUpdateRequest request
+    );
+
+    @Operation(
+        summary = "댓글 삭제",
+        description = "특정 댓글을 삭제합니다."
+    )
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "댓글 삭제 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "댓글을 찾을 수 없습니다.")
+    })
+    ResponseEntity<Void> deleteComment(
+        @Parameter(description = "문서 ID", example = "1")
+        @PathVariable Long documentId,
+
+        @Parameter(description = "댓글 ID", example = "1")
+        @PathVariable Long commentId,
+
+        @Parameter(description = "회원 ID: 로그인 적용 시 @AuthenticationPrincipal로 변경할 예정", example = "1")
+        @RequestParam Long memberId
+    );
+}


### PR DESCRIPTION
## 📄Summary
- 첨부파일(이력서/포트폴리오) API(AttachmentFileAPI)와 댓글 API(CommentApi)에 swagger 설정을 추가했습니다.

<br><br>

## 🙋🏻 More
- 이번에도 #70 PR이 머지된 후에, 머지되어야 하는 PR입니다.
- base branch도 develop이 아니라 #70 PR의 branch로 걸어놨습니다.

<br><br>

## 🔗관련 이슈
- close #68 